### PR TITLE
Changes I had to implement for this tester to work for me

### DIFF
--- a/alg-tester
+++ b/alg-tester
@@ -91,7 +91,7 @@ process_round ()
 	local MAX_TIME_NUM
 	MAX_TIME_NUM=$(tr -d 'smhd' <<< "$MAX_TIME")
 
-	if [[ $(awk "{print ($time >= $MAX_TIME_NUM && $MAX_TIME_NUM != 0)}") == 1 ]]
+	if [[ $(awk "BEGIN {print ($time >= $MAX_TIME_NUM && $MAX_TIME_NUM != 0)}") == 1 ]]
 	then
 		format_time="$RED$format_time$RESET"
 		stdout="TIME-OUT"

--- a/alg-tester
+++ b/alg-tester
@@ -91,7 +91,7 @@ process_round ()
 	local MAX_TIME_NUM
 	MAX_TIME_NUM=$(tr -d 'smhd' <<< "$MAX_TIME")
 
-	if [[ $(awk "BEGIN {print ($time >= $MAX_TIME_NUM && $MAX_TIME_NUM != 0)}" | cut -c1) == 1 ]]
+	if [[ $(awk "{print ($time >= $MAX_TIME_NUM && $MAX_TIME_NUM != 0)}") == 1 ]]
 	then
 		format_time="$RED$format_time$RESET"
 		stdout="TIME-OUT"
@@ -185,7 +185,7 @@ main ()
 
 		stdout=$( ( time timeout "$MAX_TIME" $RUN < "$input" 2> "$tmp_stderr" ) 2> "$tmp_time")
 		stderr=$(< "$tmp_stderr")
-		time=$(grep real < "$tmp_time" | awk '{print $2}' | sed 's/0m//' | tr -d s)
+		time=$(grep real < "$tmp_time" | awk '{print $2}' | sed 's/0m//' | tr -d s | tr ',' '.')
 
 		process_round
 		print_round

--- a/alg-tester
+++ b/alg-tester
@@ -91,7 +91,7 @@ process_round ()
 	local MAX_TIME_NUM
 	MAX_TIME_NUM=$(tr -d 'smhd' <<< "$MAX_TIME")
 
-	if [[ $(awk "BEGIN {print ($time >= $MAX_TIME_NUM && $MAX_TIME_NUM != 0)}") == 1 ]]
+	if [[ $(awk "BEGIN {print ($time >= $MAX_TIME_NUM && $MAX_TIME_NUM != 0)}" | cut -c1) == 1 ]]
 	then
 		format_time="$RED$format_time$RESET"
 		stdout="TIME-OUT"

--- a/alg-tester
+++ b/alg-tester
@@ -183,7 +183,7 @@ main ()
 		answer_file=${input%in}out
 		answer=$(< "$answer_file")
 
-		stdout=$( ( time timeout "$MAX_TIME" "$RUN" < "$input" 2> "$tmp_stderr" ) 2> "$tmp_time")
+		stdout=$( ( time timeout "$MAX_TIME" $RUN < "$input" 2> "$tmp_stderr" ) 2> "$tmp_time")
 		stderr=$(< "$tmp_stderr")
 		time=$(grep real < "$tmp_time" | awk '{print $2}' | sed 's/0m//' | tr -d s)
 


### PR DESCRIPTION
Hey Bram,

First of all, thanks for putting this project together. It's been quite useful to me over the past few months.

# Description

Earlier today I decided to update my `bin-tester` to the new version, to see what you'd added since downloading it a while back. After doing so, I noticed it no longer worked for me. Specifically, it would print the header line, and then nothing else.
After fixing that issue, I ran into another issue where the program would go through all the samples, printing an error for each one. The debug information stated that the error was the following: `timeout: failed to run command ‘python3 ../actor_picker/actor_picker.py’: No such file or directory`. However, this file definitely does exist. 
I have also resolved this issue on my side.

## Relevant information
- Program type: Python
- Version: 3.6.8

## Issue 1

On line `94` of `alg-tester`, the line `if [[ $(awk "{print ($time >= $MAX_TIME_NUM && $MAX_TIME_NUM != 0)}") == 1 ]]` would never terminate. Values for `$time` and `$MAX_TIME_NUM` during testing were `0,002` and `1` respectively.
Adding `BEGIN` at the start of the string parsed by awk, and then cutting the output, fixed this issue for me. See the commits connected to this pull request for more information.

## Issue 2
On line `186` of `alg-tester`, the line `stdout=$( ( time timeout "$MAX_TIME" "$RUN" < "$input" 2> "$tmp_stderr" ) 2> "$tmp_time")` would throw an exception stating that no such file can be found, despite the existence of the file. The exact error is `timeout: failed to run command ‘python3 ../actor_picker/actor_picker.py’: No such file or directory`. Removing the quotes surrounding `$RUN` has resolved this issue for me. Note that this was only tested on Python 3.6.8, and not with Java or C++. See the commits connected to this pull request for more information.

# What now?
I would recommend testing whether these solutions do not break for Java and C++ projects, before considering accepting this pull request. I do not have time for that right now.

### Sidenote
I also ran into an issue regarding some of the output samples I downloaded myself. The echo's and printf's for values from the `actor_matching` problem would "reset" the current position to print at to be at the start of the string again.
Essentially, it would print something like:
```
        0,024   Mark            Mark
```
instead of 
```
a1.in       Mark          Mark           0,024
```
I suspect this is somehow related to line endings. Perhaps I downloaded the files on Windows? After removing newlines, spaces etc. from the values in the `answer_file` using `answer=${answer//[$'\t\r\n']}`, all issues disappeared. Furthermore, after removing the newlines from the `*.out` files, all issues disappeared permanently.
This is not an issue on your side, but if someone experiences weird issues regarding printing like I had, I would recommend removing all newlines from the `*.out` files.

Thanks again for putting this project together.