### PR TITLE
Allow the script to be called from a different directory

### DIFF
--- a/alg-tester
+++ b/alg-tester
@@ -2,10 +2,11 @@
 # AUTHOR: Bram Pulles
 
 # Take the default values from the defaults file.
-source $(dirname $0)/defaults || exit 1
+readonly DIR=$(dirname "$0")
+source "$DIR"/defaults
 
-readonly MAN_PAGE=$(dirname $0)/alg-tester.1
-readonly VERSION=2.0.1
+readonly MAN_PAGE=$DIR/alg-tester.1
+readonly VERSION=2.0.2
 
 # Set some variables for colors.
 readonly GREEN='\e[32m'

--- a/alg-tester
+++ b/alg-tester
@@ -2,9 +2,9 @@
 # AUTHOR: Bram Pulles
 
 # Take the default values from the defaults file.
-source defaults || exit 1
+source $(dirname $0)/defaults || exit 1
 
-readonly MAN_PAGE=alg-tester.1
+readonly MAN_PAGE=$(dirname $0)/alg-tester.1
 readonly VERSION=2.0.1
 
 # Set some variables for colors.


### PR DESCRIPTION
When executing the script from a different directory than the one with the script, it will complain that it can't find the defaults file. My modification uses the path that was used to call the script as a base for the location of defaults and man-page.